### PR TITLE
fix: do not update the result of locals() directly

### DIFF
--- a/ydb/topic.py
+++ b/ydb/topic.py
@@ -321,7 +321,7 @@ class TopicClient:
         if not decoder_executor:
             decoder_executor = self._executor
 
-        args = locals()
+        args = locals().copy()
         del args["self"]
         self._check_closed()
 
@@ -342,7 +342,7 @@ class TopicClient:
         encoders: Optional[Mapping[_ydb_topic_public_types.PublicCodec, Callable[[bytes], bytes]]] = None,
         encoder_executor: Optional[concurrent.futures.Executor] = None,  # default shared client executor pool
     ) -> TopicWriter:
-        args = locals()
+        args = locals().copy()
         del args["self"]
         self._check_closed()
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

In my environment `self` is not removed from the `args` dictionary, so I get an error of multiple `self` arguments in a constructor method.

Issue Number: N/A

After this fix reader and writer can be actually created

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
